### PR TITLE
Fix: Extend regex to capture 7-digit 2FA codes

### DIFF
--- a/2fa-read-code/src/index.js
+++ b/2fa-read-code/src/index.js
@@ -136,7 +136,7 @@ function preProcessMessage(msg) {
 
 /**
  * Read SMS verification code
- * Digit 3-6 digits
+ * Digit 3-7 digits
  * Prefer longer codes, skip dates and currencies.
  */
 function readCaptchaFromMessage(msg) {
@@ -146,8 +146,8 @@ function readCaptchaFromMessage(msg) {
     ''
   );
 
-  // Match numbers with 3 to 6 digits, not part of currency amounts
-  const regex = /\b(?<![.,]\d|€|\$|£)(\d{3,6})(?!\d|[.,]\d|€|\$|£)\b/g;
+  // Match numbers with 3 to 7 digits, not part of currency amounts
+  const regex = /\b(?<![.,]\d|€|\$|£)(\d{3,7})(?!\d|[.,]\d|€|\$|£)\b/g;
 
   // Collect all matches
   const matches = [];


### PR DESCRIPTION
Updated the regular expression in the readCaptchaFromMessage function to include 7-digit authentication codes. Previously, the regex was limited to 3-6 digits, preventing extraction of longer codes such as those sent by SendGrid.

Tested with sample messages containing 7-digit codes to ensure successful extraction.

Before:
`const regex = /\b(?<![.,]\d|€|\$|£)(\d{3,6})(?!\d|[.,]\d|€|\$|£)\b/g;`

After:
`const regex = /\b(?<![.,]\d|€|\$|£)(\d{3,7})(?!\d|[.,]\d|€|\$|£)\b/g;`
